### PR TITLE
fix nesting for global root prefix, close cssinjs/jss#567

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,7 @@ import {RuleList} from 'jss'
 const propKey = '@global'
 const prefixKey = '@global '
 
-class GlobalContainerRule {
-  type = 'global'
-
+class GlobalRule {
   constructor(key, styles, options) {
     this.key = key
     this.options = options
@@ -13,12 +11,6 @@ class GlobalContainerRule {
       ...options,
       parent: this
     })
-
-    for (const selector in styles) {
-      this.rules.add(selector, styles[selector], {selector})
-    }
-
-    this.rules.process()
   }
 
   /**
@@ -52,13 +44,27 @@ class GlobalContainerRule {
   }
 }
 
-class GlobalPrefixedRule extends GlobalContainerRule {
+class GlobalContainerRule extends GlobalRule {
+  constructor(key, styles, options) {
+    super(key, styles, options)
+    this.type = 'global'
+
+    for (const selector in styles) {
+      this.rules.add(selector, styles[selector], {selector})
+    }
+
+    this.rules.process()
+  }
+}
+
+class GlobalPrefixedRule extends GlobalRule {
   constructor(name, style, options) {
-    super(propKey, {}, options)
+    super(propKey, style, options)
 
     const selector = name.substr(prefixKey.length)
 
-    this.addRule(selector, style, {selector})
+    this.rules.add(selector, style, {selector})
+    this.rules.process()
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -52,20 +52,13 @@ class GlobalContainerRule {
   }
 }
 
-class GlobalPrefixedRule {
+class GlobalPrefixedRule extends GlobalContainerRule {
   constructor(name, style, options) {
-    this.name = name
-    this.options = options
-    const selector = name.substr(prefixKey.length)
-    this.rule = options.jss.createRule(selector, style, {
-      ...options,
-      parent: this,
-      selector
-    })
-  }
+    super(propKey, {}, options)
 
-  toString(options) {
-    return this.rule.toString(options)
+    const selector = name.substr(prefixKey.length)
+
+    this.addRule(selector, style, {selector})
   }
 }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -221,6 +221,25 @@ describe('jss-global', () => {
       )
     })
 
+    it('should handle prefixed nested rules', () => {
+      const sheet = jss2.createStyleSheet({
+        '@global button': {
+          color: 'red',
+          '& span': {
+            color: 'green'
+          }
+        }
+      })
+      expect(sheet.toString()).to.be(
+        'button {\n' +
+        '  color: red;\n' +
+        '}\n' +
+        'button span {\n' +
+        '  color: green;\n' +
+        '}'
+      )
+    })
+
     it('should handle nested rules inside of a rule with comma separated selector', () => {
       const sheet = jss2.createStyleSheet({
         '@global': {


### PR DESCRIPTION
i found next error: jss-nested try to add nested rules to parent, but instance of GlobalPrefixedRule don't have rule list and related methods